### PR TITLE
Use one display with options, add tests.

### DIFF
--- a/docroot/sites/all/modules/features/build/midcamp_panels/midcamp_panels.pages_default.inc
+++ b/docroot/sites/all/modules/features/build/midcamp_panels/midcamp_panels.pages_default.inc
@@ -1338,13 +1338,15 @@ function midcamp_panels_default_page_manager_pages() {
     $display->content['new-3f496428-7245-4a52-b988-27bbf0a73120'] = $pane;
     $display->panels['left'][0] = 'new-3f496428-7245-4a52-b988-27bbf0a73120';
     $pane = new stdClass();
-    $pane->pid = 'new-37e70696-e482-420e-b675-1995428e196f';
+    $pane->pid = 'new-c08a30ac-6950-4458-9476-e8d58d2c2016';
     $pane->panel = 'middle';
     $pane->type = 'views_panes';
-    $pane->subtype = 'front_news-panel_pane_2';
+    $pane->subtype = 'front_news-panel_pane_1';
     $pane->shown = TRUE;
     $pane->access = array();
-    $pane->configuration = array();
+    $pane->configuration = array(
+      'offset' => '1',
+    );
     $pane->cache = array();
     $pane->style = array(
       'settings' => NULL,
@@ -1353,17 +1355,19 @@ function midcamp_panels_default_page_manager_pages() {
     $pane->extras = array();
     $pane->position = 0;
     $pane->locks = array();
-    $pane->uuid = '37e70696-e482-420e-b675-1995428e196f';
-    $display->content['new-37e70696-e482-420e-b675-1995428e196f'] = $pane;
-    $display->panels['middle'][0] = 'new-37e70696-e482-420e-b675-1995428e196f';
+    $pane->uuid = 'c08a30ac-6950-4458-9476-e8d58d2c2016';
+    $display->content['new-c08a30ac-6950-4458-9476-e8d58d2c2016'] = $pane;
+    $display->panels['middle'][0] = 'new-c08a30ac-6950-4458-9476-e8d58d2c2016';
     $pane = new stdClass();
-    $pane->pid = 'new-866806a3-739f-47f1-8ebb-42aaae75e57d';
+    $pane->pid = 'new-51823432-b208-4a4d-b974-ca1a7a048bd6';
     $pane->panel = 'right';
     $pane->type = 'views_panes';
-    $pane->subtype = 'front_news-panel_pane_5';
+    $pane->subtype = 'front_news-panel_pane_1';
     $pane->shown = TRUE;
     $pane->access = array();
-    $pane->configuration = array();
+    $pane->configuration = array(
+      'offset' => '2',
+    );
     $pane->cache = array();
     $pane->style = array(
       'settings' => NULL,
@@ -1372,9 +1376,9 @@ function midcamp_panels_default_page_manager_pages() {
     $pane->extras = array();
     $pane->position = 0;
     $pane->locks = array();
-    $pane->uuid = '866806a3-739f-47f1-8ebb-42aaae75e57d';
-    $display->content['new-866806a3-739f-47f1-8ebb-42aaae75e57d'] = $pane;
-    $display->panels['right'][0] = 'new-866806a3-739f-47f1-8ebb-42aaae75e57d';
+    $pane->uuid = '51823432-b208-4a4d-b974-ca1a7a048bd6';
+    $display->content['new-51823432-b208-4a4d-b974-ca1a7a048bd6'] = $pane;
+    $display->panels['right'][0] = 'new-51823432-b208-4a4d-b974-ca1a7a048bd6';
   $display->hide_title = PANELS_TITLE_NONE;
   $display->title_pane = '0';
   $handler->conf['display'] = $display;
@@ -1389,7 +1393,10 @@ function midcamp_panels_default_page_manager_pages() {
   $page->admin_title = 'page-become-a-sponsor';
   $page->admin_description = '';
   $page->path = 'become-a-sponsor';
-  $page->access = array();
+  $page->access = array(
+    'type' => 'none',
+    'settings' => NULL,
+  );
   $page->menu = array(
     'type' => 'normal',
     'title' => 'Become a Sponsor',
@@ -1482,7 +1489,10 @@ function midcamp_panels_default_page_manager_pages() {
   $page->admin_title = 'Schedule';
   $page->admin_description = '';
   $page->path = 'schedule/!day';
-  $page->access = array();
+  $page->access = array(
+    'type' => 'none',
+    'settings' => NULL,
+  );
   $page->menu = array();
   $page->arguments = array(
     'day' => array(
@@ -2288,7 +2298,10 @@ function midcamp_panels_default_page_manager_pages() {
   $page->admin_title = 'Sponsors';
   $page->admin_description = '';
   $page->path = 'sponsors';
-  $page->access = array();
+  $page->access = array(
+    'type' => 'none',
+    'settings' => NULL,
+  );
   $page->menu = array(
     'type' => 'normal',
     'title' => 'Sponsors',
@@ -2546,6 +2559,8 @@ function midcamp_panels_default_page_manager_pages() {
   $page->access = array(
     'plugins' => array(),
     'logic' => 'and',
+    'type' => 'none',
+    'settings' => NULL,
   );
   $page->menu = array();
   $page->arguments = array();

--- a/docroot/sites/all/modules/features/build/midcamp_views/midcamp_views.views_default.inc
+++ b/docroot/sites/all/modules/features/build/midcamp_views/midcamp_views.views_default.inc
@@ -2287,9 +2287,10 @@ function midcamp_views_views_default_views() {
   $handler->display->display_options['menu']['context'] = 0;
   $handler->display->display_options['menu']['context_only_inline'] = 0;
 
-  /* Display: first news item content pane */
-  $handler = $view->new_display('panel_pane', 'first news item content pane', 'panel_pane_1');
+  /* Display: News item content pane */
+  $handler = $view->new_display('panel_pane', 'News item content pane', 'panel_pane_1');
   $handler->display->display_options['defaults']['title'] = FALSE;
+  $handler->display->display_options['display_description'] = 'Allows you to embed news content, with an offset';
   $handler->display->display_options['defaults']['pager'] = FALSE;
   $handler->display->display_options['pager']['type'] = 'some';
   $handler->display->display_options['pager']['options']['items_per_page'] = '1';
@@ -2315,64 +2316,15 @@ function midcamp_views_views_default_views() {
   $handler->display->display_options['filters']['promote']['table'] = 'node';
   $handler->display->display_options['filters']['promote']['field'] = 'promote';
   $handler->display->display_options['filters']['promote']['value'] = '1';
-
-  /* Display: second news item content pane */
-  $handler = $view->new_display('panel_pane', 'second news item content pane', 'panel_pane_2');
-  $handler->display->display_options['defaults']['title'] = FALSE;
-  $handler->display->display_options['defaults']['pager'] = FALSE;
-  $handler->display->display_options['pager']['type'] = 'some';
-  $handler->display->display_options['pager']['options']['items_per_page'] = '1';
-  $handler->display->display_options['pager']['options']['offset'] = '1';
-  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
-  $handler->display->display_options['defaults']['filters'] = FALSE;
-  /* Filter criterion: Content: Published */
-  $handler->display->display_options['filters']['status']['id'] = 'status';
-  $handler->display->display_options['filters']['status']['table'] = 'node';
-  $handler->display->display_options['filters']['status']['field'] = 'status';
-  $handler->display->display_options['filters']['status']['value'] = 1;
-  $handler->display->display_options['filters']['status']['group'] = 1;
-  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
-  /* Filter criterion: Content: Type */
-  $handler->display->display_options['filters']['type']['id'] = 'type';
-  $handler->display->display_options['filters']['type']['table'] = 'node';
-  $handler->display->display_options['filters']['type']['field'] = 'type';
-  $handler->display->display_options['filters']['type']['value'] = array(
-    'news' => 'news',
-  );
-  /* Filter criterion: Content: Promoted to front page */
-  $handler->display->display_options['filters']['promote']['id'] = 'promote';
-  $handler->display->display_options['filters']['promote']['table'] = 'node';
-  $handler->display->display_options['filters']['promote']['field'] = 'promote';
-  $handler->display->display_options['filters']['promote']['value'] = '1';
-
-  /* Display: third news item content pane */
-  $handler = $view->new_display('panel_pane', 'third news item content pane', 'panel_pane_5');
-  $handler->display->display_options['defaults']['title'] = FALSE;
-  $handler->display->display_options['defaults']['pager'] = FALSE;
-  $handler->display->display_options['pager']['type'] = 'some';
-  $handler->display->display_options['pager']['options']['items_per_page'] = '1';
-  $handler->display->display_options['pager']['options']['offset'] = '2';
-  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
-  $handler->display->display_options['defaults']['filters'] = FALSE;
-  /* Filter criterion: Content: Published */
-  $handler->display->display_options['filters']['status']['id'] = 'status';
-  $handler->display->display_options['filters']['status']['table'] = 'node';
-  $handler->display->display_options['filters']['status']['field'] = 'status';
-  $handler->display->display_options['filters']['status']['value'] = 1;
-  $handler->display->display_options['filters']['status']['group'] = 1;
-  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
-  /* Filter criterion: Content: Type */
-  $handler->display->display_options['filters']['type']['id'] = 'type';
-  $handler->display->display_options['filters']['type']['table'] = 'node';
-  $handler->display->display_options['filters']['type']['field'] = 'type';
-  $handler->display->display_options['filters']['type']['value'] = array(
-    'news' => 'news',
-  );
-  /* Filter criterion: Content: Promoted to front page */
-  $handler->display->display_options['filters']['promote']['id'] = 'promote';
-  $handler->display->display_options['filters']['promote']['table'] = 'node';
-  $handler->display->display_options['filters']['promote']['field'] = 'promote';
-  $handler->display->display_options['filters']['promote']['value'] = '1';
+  $handler->display->display_options['allow']['use_pager'] = 0;
+  $handler->display->display_options['allow']['items_per_page'] = 0;
+  $handler->display->display_options['allow']['offset'] = 'offset';
+  $handler->display->display_options['allow']['link_to_view'] = 0;
+  $handler->display->display_options['allow']['more_link'] = 0;
+  $handler->display->display_options['allow']['path_override'] = 0;
+  $handler->display->display_options['allow']['title_override'] = 0;
+  $handler->display->display_options['allow']['exposed_form'] = 0;
+  $handler->display->display_options['allow']['fields_override'] = 0;
   $export['front_news'] = $view;
 
   $view = new view();

--- a/tests/features/frontpage.feature
+++ b/tests/features/frontpage.feature
@@ -4,10 +4,24 @@ Feature: Front page content
   @midcamp-224
   Scenario: Front page content
     Given I am an anonymous user
+    Given "news" content:
+      | title                     | promote | body                  |
+      | Example news 1            | 1       | Lorem Ipsum Example 1 |
+      | Example news 2            | 0       | Lorem Ipsum Example 2 |
+      | Example news 3            | 1       | Lorem Ipsum Example 3 |
+      | Example news 4            | 0       | Lorem Ipsum Example 4 |
+      | Example news 5            | 1       | Lorem Ipsum Example 5 |
     When I am on the homepage
 
     #Date and venue block (not part of story description)
     Then I should see "March 17-20, 2016 at University of Illinois at Chicago (UIC)" in the header_top
+
+    # News section
+    Then I should see "Example news 1"
+    Then I should not see "Example news 2"
+    Then I should see "Example new 3"
+    Then I should not see "Example news 4"
+    Then I should see "Example news 5"
 
     #Info section
     #And I see the heading "Save the Date for MidCamp 2016"


### PR DESCRIPTION
Reduces front_news to a single display with exposed offset field. Offset configured on front page in page manager. Test checks fitlers work.
